### PR TITLE
Remove the error case where Highlight already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,18 @@ Returns an array of all objects that are currently highlighted.
 
 ### Clear()
 Removes all highlights.
+
+## Configuration
+Configuration is controlled by passing in a Configuration object. The Configuration should specify the following properties:
+	FillColor: Color3;
+        The Color to fill the object in with.
+	OutlineColor: Color3;
+        The Color to outline the object with.
+	FillTransparency: number;
+        The transparency of the filler portion of the highlight. Should be set between 0-1; 1 is fully invisible.
+	OutlineTransparency: number;
+        The transparency for the outline of the highlight. Should be set between 0-1; 1 is fully invisible.
+	MeshOutlineSize: number;
+        The Outline Size to use with meshes. This should be small; a good example value is 0.025.
+	BoxOutlineSize: number;
+        The Outline Size to use with box highlights. This is used for regular parts.

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,24 +22,32 @@ function Configure(config: Configuration) {
 }
 
 // Highlights the target part. Applies the given configuration.
-export function Highlight(part: BasePart, configuration: Configuration) {
-	assert(
-		!highlights.has(part),
-		`Attempted to highlight ${part}, but a previous highlight was already applied. Please remove the highlight first.`,
-	);
+export function Highlight(part: BasePart, configuration: Configuration): boolean {
+	// If the object is already highlighted, we can skip highlighting
+	if (highlights.has(part)) {
+		return false;
+	}
 
 	Configure(configuration);
 
 	const HighlightClass = part.IsA("MeshPart") ? MeshHighlighter : BoxHighlighter;
 	const highlighterClass = new HighlightClass(part, highlightsFolder);
 	highlights.set(part, highlighterClass);
+
+	return true;
 }
 
 // Removes highlight from a part.
-export function RemoveHighlight(part: BasePart) {
-	assert(highlights.get(part), `Could not find highlight for part: ${part}`);
+export function RemoveHighlight(part: BasePart): boolean {
+	// If the part isn't highlighted, we can skip without doing anything
+	if (!highlights.has(part)) {
+		return false;
+	}
+
 	highlights.get(part)?.Destroy();
 	highlights.delete(part);
+
+	return true;
 }
 export function Clear() {
 	highlights.forEach((highlight) => highlight.Destroy());


### PR DESCRIPTION
Instead of throwing an error, will now silently fail and return a boolean that can be used to catch the error. Allows an object to be highlighted multiple times without having to look for the error in the calling code.